### PR TITLE
Implement AI-powered alert triage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your-openai-key-here
+SLACK_WEBHOOK_URL=your-slack-webhook-url-here
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# AI Incident Triage Assistant
+
+This simple project demonstrates receiving a Prometheus AlertManager payload,
+using OpenAI to generate a possible root cause and fix, and sending the summary
+to Slack.
+
+## Setup
+
+1. Install dependencies in a virtual environment:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.example` to `.env` and fill in your OpenAI API key and Slack
+   webhook URL.
+
+## Running
+
+Start the FastAPI server with:
+
+```bash
+uvicorn main:app --reload
+```
+
+The server will listen on `http://127.0.0.1:8000` by default.
+
+## Testing the `/alert` endpoint
+
+You can send the sample alert using `curl`:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     --data @alert_example.json \
+     http://127.0.0.1:8000/alert
+```
+

--- a/alert_example.json
+++ b/alert_example.json
@@ -1,0 +1,19 @@
+{
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "HighCPUUsage",
+        "severity": "critical",
+        "instance": "web-server-1",
+        "service": "user-service"
+      },
+      "annotations": {
+        "summary": "CPU usage is above 80% for 5 minutes",
+        "description": "Pod 'user-service' has CPU > 80% for over 5 mins"
+      },
+      "startsAt": "2025-06-25T10:00:00Z"
+    }
+  ]
+}
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, Request
+from dotenv import load_dotenv
+
+from openai_handler import process_alert_with_ai
+from slack_notify import send_slack_message
+
+# Load environment variables
+load_dotenv()
+
+app = FastAPI()
+
+
+@app.post("/alert")
+async def receive_alert(request: Request):
+    """Endpoint to receive Prometheus alert payloads."""
+    payload = await request.json()
+    alerts = payload.get("alerts", [])
+    if not alerts:
+        return {"status": "no alerts found"}
+
+    alert = alerts[0]
+    labels = alert.get("labels", {})
+    annotations = alert.get("annotations", {})
+
+    alert_data = {
+        "alertname": labels.get("alertname"),
+        "service": labels.get("service"),
+        "severity": labels.get("severity"),
+        "labels": labels,
+        "annotations": annotations,
+    }
+
+    summary = process_alert_with_ai(alert_data)
+    # Include alert info in summary for slack message
+    summary.update({
+        "alertname": alert_data.get("alertname"),
+        "service": alert_data.get("service"),
+    })
+    send_slack_message(summary)
+    return {"status": "processed", "summary": summary}
+

--- a/openai_handler.py
+++ b/openai_handler.py
@@ -1,0 +1,47 @@
+import os
+import json
+import openai
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Set OpenAI API key
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+def process_alert_with_ai(alert_data: dict) -> dict:
+    """Send alert information to OpenAI and return a summary dictionary."""
+    alert_name = alert_data.get("alertname", "")
+    description = alert_data.get("annotations", {}).get("description", "")
+    severity = alert_data.get("severity", "")
+
+    prompt = (
+        "You are an SRE. Here's the alert:\n"
+        f"- Alert Name: {alert_name}\n"
+        f"- Description: {description}\n"
+        f"- Severity: {severity}\n"
+        "Suggest the root cause and a fix. "
+        "Respond using this JSON format:\n"
+        "{\n  \"summary\": \"<short summary>\",\n"
+        "  \"probable_cause\": \"<probable cause>\",\n"
+        "  \"recommended_fix\": \"<recommended fix>\"\n}"
+    )
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+        )
+        content = response.choices[0].message.content.strip()
+        summary_dict = json.loads(content)
+    except Exception as e:
+        # In case of an error we return a simple message
+        summary_dict = {
+            "summary": "Failed to get AI response",
+            "probable_cause": str(e),
+            "recommended_fix": "Check OpenAI configuration",
+        }
+    return summary_dict
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+openai
+python-dotenv
+httpx
+

--- a/slack_notify.py
+++ b/slack_notify.py
@@ -1,0 +1,34 @@
+import os
+import httpx
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+
+def send_slack_message(summary_dict: dict) -> None:
+    """Send a formatted Slack message using an incoming webhook."""
+    if not WEBHOOK_URL:
+        print("No Slack webhook URL configured")
+        return
+
+    alertname = summary_dict.get("alertname", "")
+    service = summary_dict.get("service", "")
+    summary = summary_dict.get("summary", "")
+    probable_cause = summary_dict.get("probable_cause", "")
+    recommended_fix = summary_dict.get("recommended_fix", "")
+
+    message = (
+        f":rotating_light: *{alertname}* on `{service}`\n"
+        f"*Summary:* {summary}\n"
+        f"*Probable Cause:* {probable_cause}\n"
+        f"*Recommended Fix:* {recommended_fix}"
+    )
+
+    try:
+        httpx.post(WEBHOOK_URL, json={"text": message})
+    except Exception as e:
+        print(f"Failed to send Slack message: {e}")
+


### PR DESCRIPTION
## Summary
- create FastAPI endpoint for incoming alerts
- send alert details to OpenAI for root cause & fix suggestions
- deliver AI summary to Slack using webhook
- provide env vars, example payload, and instructions

## Testing
- `python -m py_compile main.py openai_handler.py slack_notify.py`

------
https://chatgpt.com/codex/tasks/task_e_685d9549f540833086cb5b2452c018c2