### PR TITLE
Add log/trace enrichment with Grafana stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 __pycache__/
 venv/
-.env
-*.pyc
+.env*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # AI Incident Triage Assistant
 
-This project demonstrates receiving a Prometheus AlertManager payload,
-using OpenAI to generate a possible root cause and fix, and sending the summary
-to Slack.
+This project demonstrates receiving a Prometheus AlertManager payload, using OpenAI to generate a possible root cause and fix, and sending the summary to Slack.
 
 ## Setup
 
@@ -10,8 +8,7 @@ to Slack.
    ```bash
    pip install -r requirements.txt
    ```
-2. Copy `.env.example` to `.env` and fill in your OpenAI API key and Slack
-   webhook URL.
+2. Copy `.env.example` to `.env` and fill in your OpenAI API key and Slack webhook URL.
 
 ## Running
 

--- a/alertmanager.yml
+++ b/alertmanager.yml
@@ -6,5 +6,5 @@ route:
 
 receivers:
   - name: 'triage-bot'
-    webhook_configs:
-      - url: 'http://172.17.0.1:8000/alert'
+    webhook_configs:      - url: 'http://bot:8000/alert'
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,47 @@ services:
     image: prom/node-exporter
     ports:
       - "9100:9100"
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+      - loki
+      - tempo
+
+  loki:
+    image: grafana/loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  tempo:
+    image: grafana/tempo
+    command: ["-config.file=/etc/tempo/local.yaml"]
+    ports:
+      - "3200:3200"
+      - "4317:4317"
+
+  otel-collector:
+    image: otel/opentelemetry-collector:0.86.0
+    command: ["--config=/etc/otel-config.yaml"]
+    volumes:
+      - ./otel-config.yaml:/etc/otel-config.yaml
+    ports:
+      - "4317:4317"
+
+  bot:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    depends_on:
+      - alertmanager
+      - prometheus
+      - loki
+      - tempo
+      - otel-collector
+

--- a/main.py
+++ b/main.py
@@ -1,13 +1,40 @@
+from datetime import datetime
 from fastapi import FastAPI, Request
 from dotenv import load_dotenv
+import httpx
 
 from openai_handler import process_alert_with_ai
 from slack_notify import send_slack_message
 
-# Load environment variables
 load_dotenv()
 
 app = FastAPI()
+
+
+async def query_loki_logs(instance: str) -> str:
+    """Fetch recent logs for the given instance from Loki."""
+    if not instance:
+        return ""
+    url = "http://loki:3100/loki/api/v1/query_range"
+    params = {"query": f'{{instance="{instance}"}}', "limit": 20}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params, timeout=5.0)
+            resp.raise_for_status()
+            data = resp.json()
+            result = data.get("data", {}).get("result", [])
+            if result:
+                logs = [v[1] for v in result[0].get("values", [])]
+                return "\n".join(logs[-5:])
+    except Exception as exc:
+        return f"Error fetching logs: {exc}"
+    return "No logs found"
+
+
+def generate_tempo_trace_url(service: str) -> str:
+    """Return a placeholder Tempo trace URL for the service."""
+    ts = int(datetime.utcnow().timestamp())
+    return f"http://tempo:3200/trace/{service}/{ts}"
 
 
 @app.post("/alert")
@@ -31,11 +58,15 @@ async def receive_alert(request: Request):
     }
 
     summary = process_alert_with_ai(alert_data)
-    # Include alert info in summary for slack message
     summary.update({
         "alertname": alert_data.get("alertname"),
         "service": alert_data.get("service"),
     })
+
+    instance = labels.get("instance")
+    summary["log_snippet"] = await query_loki_logs(instance)
+    summary["trace_url"] = generate_tempo_trace_url(alert_data.get("service"))
+
     send_slack_message(summary)
     return {"status": "processed", "summary": summary}
 

--- a/otel-config.yaml
+++ b/otel-config.yaml
@@ -1,0 +1,23 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/tempo]
+    logs:
+      receivers: [otlp]
+      exporters: [loki]
+

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -14,3 +14,4 @@ scrape_configs:
   - job_name: "node"
     static_configs:
       - targets: ["node-exporter:9100"]
+

--- a/slack_notify.py
+++ b/slack_notify.py
@@ -6,12 +6,27 @@ load_dotenv()
 
 SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
 
-def send_slack_message(summary: dict):
+
+def send_slack_message(summary: dict) -> None:
+    """Send formatted alert details to Slack."""
     alertname = summary.get("alertname", "N/A")
     service = summary.get("service", "N/A")
     title = summary.get("summary", "No summary")
     cause = summary.get("probable_cause", "Unknown cause")
     fix = summary.get("recommended_fix", "No fix suggested")
+    logs = summary.get("log_snippet", "No logs found")
+    trace_url = summary.get("trace_url", "")
+
+    text_parts = [
+        f"*Summary:*\n{title}",
+        f"*Probable Cause:*\n{cause}",
+        f"*Recommended Fix:*\n{fix}",
+    ]
+    if logs:
+        text_parts.append(f"*Logs:*\n{logs}")
+    if trace_url:
+        text_parts.append(f"*Trace:* <{trace_url}|View Trace>")
+    text_block = "\n\n".join(text_parts)
 
     message = {
         "text": f":rotating_light: *Incident Alert: `{alertname}`*",
@@ -21,19 +36,16 @@ def send_slack_message(summary: dict):
                 "text": {
                     "type": "plain_text",
                     "text": f"🚨 {alertname} on {service}",
-                    "emoji": True
-                }
+                    "emoji": True,
+                },
             },
             {
                 "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*Summary:*\n{title}\n\n*Probable Cause:*\n{cause}\n\n*Recommended Fix:*\n{fix}"
-                }
-            }
-        ]
+                "text": {"type": "mrkdwn", "text": text_block},
+            },
+        ],
     }
 
     response = httpx.post(SLACK_WEBHOOK_URL, json=message)
-    if response.status_code != 200:
-        print("Slack send error:", response.text)
+    if response.status_code != 200:        print("Slack send error:", response.text)
+


### PR DESCRIPTION
## Summary
- add Dockerfile for FastAPI bot
- extend docker-compose with Grafana, Loki, Tempo and OpenTelemetry Collector
- add OpenTelemetry Collector config
- enrich alerts with Loki logs and Tempo trace link
- improve Slack notifications with logs and trace URL
- clean documentation and configs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d6af0936083308cbb99f3b8a496a9